### PR TITLE
Dodanie informacji (earned money, placed turrets) na ekranie śmierci

### DIFF
--- a/Assets/Prefabs/Misc/Enemies/Mage.prefab
+++ b/Assets/Prefabs/Misc/Enemies/Mage.prefab
@@ -298,6 +298,9 @@ MonoBehaviour:
   maxHealth: 100
   healthBar: {fileID: 6528037127942012915}
   Money: {fileID: 8232618329337579605, guid: bfffc6ff1fda0554e9116830a5e64295, type: 3}
+  killedEnemies: 0
+  killedEnemiesText: {fileID: 1742110861467734902, guid: 2c6d88c1ae40b4a47a5409e46f926037,
+    type: 3}
 --- !u!114 &-7126138228824471991
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Misc/Enemies/Melee.prefab
+++ b/Assets/Prefabs/Misc/Enemies/Melee.prefab
@@ -115,6 +115,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemy: {fileID: 254587136096602259}
+  enemyDamage: 0
   whatIsPlayer:
     serializedVersion: 2
     m_Bits: 8192
@@ -122,9 +123,11 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 262144
   inRangeOfDefendingStructure: 0
+  inAttackRangeOfDefendingStructure: 0
   defendingStructureLayer:
     serializedVersion: 2
     m_Bits: 33554432
+  defendingStructure: {fileID: 0}
 --- !u!195 &254587136096602259
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -178,6 +181,9 @@ MonoBehaviour:
   maxHealth: 100
   healthBar: {fileID: 4331075707790240842}
   Money: {fileID: 8232618329337579605, guid: bfffc6ff1fda0554e9116830a5e64295, type: 3}
+  killedEnemies: 0
+  killedEnemiesText: {fileID: 1742110861467734902, guid: 2c6d88c1ae40b4a47a5409e46f926037,
+    type: 3}
 --- !u!65 &2956680218366870976
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Misc/Enemies/Range.prefab
+++ b/Assets/Prefabs/Misc/Enemies/Range.prefab
@@ -298,6 +298,9 @@ MonoBehaviour:
   maxHealth: 100
   healthBar: {fileID: 4814133869411677445}
   Money: {fileID: 8232618329337579605, guid: bfffc6ff1fda0554e9116830a5e64295, type: 3}
+  killedEnemies: 0
+  killedEnemiesText: {fileID: 1742110861467734902, guid: 2c6d88c1ae40b4a47a5409e46f926037,
+    type: 3}
 --- !u!114 &5069802828548225875
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Misc/Enemies/Tank.prefab
+++ b/Assets/Prefabs/Misc/Enemies/Tank.prefab
@@ -115,12 +115,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemy: {fileID: 6142323270256696194}
+  enemyDamage: 0
   whatIsPlayer:
     serializedVersion: 2
     m_Bits: 8192
   buildingLayermask:
     serializedVersion: 2
     m_Bits: 262144
+  inRangeOfDefendingStructure: 0
+  inAttackRangeOfDefendingStructure: 0
+  defendingStructureLayer:
+    serializedVersion: 2
+    m_Bits: 0
+  defendingStructure: {fileID: 0}
 --- !u!195 &6142323270256696194
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -174,6 +181,9 @@ MonoBehaviour:
   maxHealth: 100
   healthBar: {fileID: 7687224234967383899}
   Money: {fileID: 8232618329337579605, guid: bfffc6ff1fda0554e9116830a5e64295, type: 3}
+  killedEnemies: 0
+  killedEnemiesText: {fileID: 1742110861467734902, guid: 2c6d88c1ae40b4a47a5409e46f926037,
+    type: 3}
 --- !u!65 &9204705765825615569
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Misc/Player.prefab
+++ b/Assets/Prefabs/Misc/Player.prefab
@@ -19982,7 +19982,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   CurrentMoney: 0
+  earnedMoney: 0
   Score: {fileID: 8858129505732173604}
+  earnedMoneyText: {fileID: 0}
 --- !u!114 &604596832
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -21700,6 +21702,8 @@ RectTransform:
   - {fileID: 1747396065052783233}
   - {fileID: 6130400622272611854}
   - {fileID: 7289221548644462160}
+  - {fileID: 8424739583720069536}
+  - {fileID: 6101431716339436078}
   m_Father: {fileID: 474865914178171237}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -21996,6 +22000,274 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MiniMap: {fileID: 8778945124501338768}
   GUI: {fileID: 1941492103226506219}
+--- !u!1 &8250842918189524069
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6101431716339436078}
+  - component: {fileID: 5498027949378446954}
+  - component: {fileID: 8564922265722221604}
+  m_Layer: 13
+  m_Name: PlacedTurrets
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6101431716339436078
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8250842918189524069}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1784601996737193232}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 49}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5498027949378446954
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8250842918189524069}
+  m_CullTransparentMesh: 1
+--- !u!114 &8564922265722221604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8250842918189524069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Placed turrets: 0'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -646.5558, y: 0, z: -643.0822, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8381614438073514226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8424739583720069536}
+  - component: {fileID: 1994816235748509411}
+  - component: {fileID: 158470648423811656}
+  m_Layer: 13
+  m_Name: EarnedMoney
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8424739583720069536
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8381614438073514226}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1784601996737193232}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 119}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1994816235748509411
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8381614438073514226}
+  m_CullTransparentMesh: 1
+--- !u!114 &158470648423811656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8381614438073514226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Earned money: 0'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -644.38135, y: 0, z: -644.39606, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8521749769954736116
 GameObject:
   m_ObjectHideFlags: 0
@@ -32985,6 +33257,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 532b53a1fe3c8984db67ea858c47a829, type: 3}
+--- !u!224 &2874718896929526135 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9023815288851839411, guid: 532b53a1fe3c8984db67ea858c47a829,
+    type: 3}
+  m_PrefabInstance: {fileID: 6547677140011641028}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2874718897732605733 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9023815288036179937, guid: 532b53a1fe3c8984db67ea858c47a829,
@@ -32997,12 +33275,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99ba1f6d596fcb74fb0a833f0625033d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2874718896929526135 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 9023815288851839411, guid: 532b53a1fe3c8984db67ea858c47a829,
-    type: 3}
-  m_PrefabInstance: {fileID: 6547677140011641028}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7170100548048004506
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3743,6 +3743,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1349504709}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &375996814 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 158470648423811656, guid: a5d1c6b1fd001ec4e921a769a3910204,
+    type: 3}
+  m_PrefabInstance: {fileID: 2874718898421768074}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &377925597
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6888,6 +6900,18 @@ Transform:
   m_Father: {fileID: 641243424}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 44.9, y: 31.4, z: -104.9}
+--- !u!114 &709531904 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8564922265722221604, guid: a5d1c6b1fd001ec4e921a769a3910204,
+    type: 3}
+  m_PrefabInstance: {fileID: 2874718898421768074}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &719052242
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20691,6 +20715,8 @@ MonoBehaviour:
   Menu: 0
   inv: {fileID: 0}
   isShop: 0
+  placedTurrets: 0
+  placedTurretsText: {fileID: 709531904}
   MainMenuInstance: {fileID: 0}
   Canvas: {fileID: 644472529}
   Prefab: {fileID: 0}
@@ -21476,6 +21502,14 @@ PrefabInstance:
       propertyPath: gunPosition
       value: 
       objectReference: {fileID: 2874718898421768076}
+    - target: {fileID: 604596831, guid: a5d1c6b1fd001ec4e921a769a3910204, type: 3}
+      propertyPath: EarnedMoney
+      value: 
+      objectReference: {fileID: 375996814}
+    - target: {fileID: 604596831, guid: a5d1c6b1fd001ec4e921a769a3910204, type: 3}
+      propertyPath: earnedMoneyText
+      value: 
+      objectReference: {fileID: 375996814}
     - target: {fileID: 963194227, guid: a5d1c6b1fd001ec4e921a769a3910204, type: 3}
       propertyPath: m_CullingMask.m_Bits
       value: 58523447
@@ -21517,6 +21551,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 158470648423811656, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_text
+      value: 'Earned money: 0'
+      objectReference: {fileID: 0}
     - target: {fileID: 429145502974990137, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
       propertyPath: m_Enabled
@@ -21548,6 +21587,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: b604cfe621aab27479d91396a364c108,
         type: 3}
+    - target: {fileID: 1984513385361842684, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2115541836800164273, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -21693,6 +21737,16 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4813116623753883910, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100874401406289734, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 17
+      objectReference: {fileID: 0}
     - target: {fileID: 5237523504196733434, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
       propertyPath: m_RootOrder
@@ -21717,6 +21771,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6101431716339436078, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 6378274478260973006, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
@@ -21743,6 +21802,11 @@ PrefabInstance:
       propertyPath: shopMenu2
       value: 
       objectReference: {fileID: 946384531}
+    - target: {fileID: 7289221548644462160, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 248
+      objectReference: {fileID: 0}
     - target: {fileID: 7374486809161113428, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
       propertyPath: m_RootOrder
@@ -21823,6 +21887,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 52.779
       objectReference: {fileID: 0}
+    - target: {fileID: 8424739583720069536, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 127
+      objectReference: {fileID: 0}
     - target: {fileID: 8483774315923964402, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}
       propertyPath: m_Layer
@@ -21837,6 +21906,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8564922265722221604, guid: a5d1c6b1fd001ec4e921a769a3910204,
+        type: 3}
+      propertyPath: m_text
+      value: 'Placed turret: 0'
       objectReference: {fileID: 0}
     - target: {fileID: 8862343092548981280, guid: a5d1c6b1fd001ec4e921a769a3910204,
         type: 3}

--- a/Assets/Scripts/Enemy/EnemyMechanics.cs
+++ b/Assets/Scripts/Enemy/EnemyMechanics.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.AI;
 

--- a/Assets/Scripts/Menu/PauseMenu.cs
+++ b/Assets/Scripts/Menu/PauseMenu.cs
@@ -18,6 +18,8 @@ public class PauseMenu : MonoBehaviour
     public GameObject SureGameover;
     public GameObject progressText;
     private WaveManagerSubscriber WaveManager;
+    private Money _money;
+    private GroundCotroller _groundCotroller;
 
 
     public GameObject GUI;
@@ -28,6 +30,8 @@ public class PauseMenu : MonoBehaviour
         pauseMenuUI.SetActive(false);
         GameIsPaused = false;
         GUI = GameObject.Find("GUI");
+        _money = FindObjectOfType<Money>();
+        _groundCotroller = FindObjectOfType<GroundCotroller>();
     }
 
     void Update()
@@ -113,12 +117,15 @@ public class PauseMenu : MonoBehaviour
     public void NoSureGameOver()
     {
         Dead.SetActive(true);
+        
         SureGameover.SetActive(false);
     }
 
     public void DeadPlayer()
     {
         Health = FindObjectOfType<HealthPlayer>();
+        _money.GetEarnedMoney();
+        _groundCotroller.GetPlacedTurrets();
         if(Health.currentHealth <= 0 || WaveManager.BuildingCount == 0)
         {
             Dead.SetActive(true);

--- a/Assets/Scripts/Player/Money.cs
+++ b/Assets/Scripts/Player/Money.cs
@@ -3,22 +3,26 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 public class Money : MonoBehaviour
 {
     public int CurrentMoney;
-    public TextMeshProUGUI Score;
+    [SerializeField] private int earnedMoney;
+    [SerializeField] private TextMeshProUGUI Score;
+    [SerializeField] private TextMeshProUGUI earnedMoneyText;
 
     public void AddMoney()
     {
-        CurrentMoney += 3; 
+        CurrentMoney += 3;
+        earnedMoney += 3;
         Score.text = CurrentMoney.ToString();
     }
     
     public void AddMoneyAmmount(int money)
     {
-        CurrentMoney += money; 
+        CurrentMoney += money;
         Score.text = CurrentMoney.ToString();
     }
 
@@ -28,15 +32,10 @@ public class Money : MonoBehaviour
         Score.text = CurrentMoney.ToString();
     }
 
-    void Start()
+    public int GetEarnedMoney()
     {
-        
+        earnedMoneyText.text = "Earned money: " + earnedMoney.ToString();
+        return earnedMoney;
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-    
 }

--- a/Assets/Scripts/Turret/GroundCotroller.cs
+++ b/Assets/Scripts/Turret/GroundCotroller.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
+using TMPro;
 using UnityEditor.Analytics;
 using UnityEditor.Experimental.TerrainAPI;
+using UnityEditor.Rendering;
 using UnityEngine;
 
 
@@ -17,8 +19,10 @@ public class GroundCotroller : MonoBehaviour
     [SerializeField] private float mouseWheelRotation;
     [SerializeField] private bool Menu;
     [SerializeField] private Inventory inv;
-    [SerializeField] private bool isShop;
     
+    [SerializeField] private bool isShop;
+    [SerializeField] private int placedTurrets;
+    [SerializeField] private TextMeshProUGUI placedTurretsText;
     //Ring Menu Controller
     [SerializeField] private RingMenu MainMenuInstance;
     [SerializeField] private GameObject Canvas;
@@ -142,11 +146,13 @@ public class GroundCotroller : MonoBehaviour
             if (Prefab != null && Prefab.name.Equals("TurretTransparent"))
             {
                 PlaceCurrentObject(0, hitInfo);
+                placedTurrets++;
                 inv.RemoveShootingTurret();
             }
             else if (Prefab != null && Prefab.name.Equals("SlowingTurretTransparent"))
             {
                 PlaceCurrentObject(1, hitInfo);
+                placedTurrets++;
                 inv.RemoveSlowingTurret();
             }
             else if (Prefab != null && Prefab.name.Equals("SlowTrapTransparent"))
@@ -299,5 +305,11 @@ public class GroundCotroller : MonoBehaviour
                 Debug.Log("Error with setting numbers in prefab array");
                 break;
         }
+    }
+
+    public int GetPlacedTurrets()
+    {
+        placedTurretsText.text = "Placed turrets: " + placedTurrets.ToString();
+        return placedTurrets;
     }
 }


### PR DESCRIPTION
<Dodanie informacji (earned money, placed turrets) na ekranie śmierci>
---

1. **Dodanie informacji (earned money, placed turrets) na ekranie śmierci** 
> Wydaję mi się to całkiem spoko, jak w bloonsach haha Tak wolno chcę się rozgrzewać przed pięknym styczniem (hlip hlip)
>Tutaj znalazłem fajny poradnik, z którego korzystałem, polecam: https://www.youtube.com/watch?v=dQw4w9WgXcQ
>A i mam nadzieję, że to działa XD Aż tak bardzo nie testowałem tego + oczywiście to jest mega wczesna faza tego feature'a Jeszcze może info o zabitych wrogach itd. itd.
